### PR TITLE
Remove user/pass from env vars to satisfy latest RabbitMQ container image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,9 +12,6 @@ services:
     ports:
       - 5672:5672
       - 15672:15672
-    environment:
-      RABBITMQ_DEFAULT_USER: user
-      RABBITMQ_DEFAULT_PASS: password
     volumes:
       - ~/.docker-conf/rabbitmq/data/:/var/lib/rabbitmq/
       - ~/.docker-conf/rabbitmq/log/:/var/log/rabbitmq

--- a/infrastructure/rabbitmq/rabbitmq.conf
+++ b/infrastructure/rabbitmq/rabbitmq.conf
@@ -1,1 +1,3 @@
 management.load_definitions = /etc/rabbitmq//definitions.json
+default_user=$RABBITMQ_USER
+default_pass=$RABBITMQ_PASS


### PR DESCRIPTION
Newer versions of the RabbitMQ container image are causing a failure:

![image](https://user-images.githubusercontent.com/4335762/128076609-5ed65fd9-f2a8-4fd6-9827-41ec9defe2a0.png)

This fix is to move those settings into the config file. After making the change, the apps completed as usual.